### PR TITLE
refactoring mistake

### DIFF
--- a/handlers/createSession.go
+++ b/handlers/createSession.go
@@ -79,13 +79,7 @@ func (h *CreateSession) tryCreateSession(r *http.Request, capabilities *capabili
 	if err != nil {
 		return nil, errors.New("reserve node error: " + err.Error())
 	}
-	//todo: посылать в мониторинг событие, если вернулся не 0
-	seleniumClient := h.ClientFactory.Create(node.Address)
-	seleniumNode := jsonwire.NewNode(seleniumClient)
-	_, err = seleniumNode.RemoveAllSessions()
-	if err != nil {
-		return nil, errors.New("Can't remove all sessions from node: " + err.Error() + ", go to next available node: " + node.String())
-	}
+
 	reverseProxy := httputil.NewSingleHostReverseProxy(&url.URL{
 		Scheme: "http",
 		Host:   node.Address,

--- a/pool/strategy/persistent/factory.go
+++ b/pool/strategy/persistent/factory.go
@@ -13,5 +13,10 @@ func (f *StrategyFactory) Create(
 	capsComparator capabilities.ComparatorInterface,
 	clientFactory jsonwire.ClientFactoryInterface,
 ) (pool.StrategyInterface, error) {
-	return &Strategy{storage, capsComparator, clientFactory}, nil
+	return &Strategy{
+		storage,
+		capsComparator,
+		clientFactory,
+		new(nodeHelperFactory),
+	}, nil
 }

--- a/pool/strategy/persistent/nodeHelper.go
+++ b/pool/strategy/persistent/nodeHelper.go
@@ -1,18 +1,21 @@
-package jsonwire
+package persistent
 
 import (
 	"fmt"
+	"github.com/qa-dev/jsonwire-grid/jsonwire"
 )
 
-type Node struct {
-	client ClientInterface
+type nodeHelperFactory struct{}
+
+func (f *nodeHelperFactory) create(abstractClient jsonwire.ClientInterface) sessionsRemover {
+	return &nodeHelper{client: abstractClient}
 }
 
-func NewNode(abstractClient ClientInterface) *Node {
-	return &Node{client: abstractClient}
+type nodeHelper struct {
+	client jsonwire.ClientInterface
 }
 
-func (n *Node) RemoveAllSessions() (int, error) {
+func (n *nodeHelper) removeAllSessions() (int, error) {
 	message, err := n.client.Sessions()
 	if err != nil {
 		return 0, fmt.Errorf("Can't get sessions, %s", err.Error())

--- a/pool/strategy/persistent/nodeHelper_test.go
+++ b/pool/strategy/persistent/nodeHelper_test.go
@@ -1,0 +1,96 @@
+package persistent
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/qa-dev/jsonwire-grid/jsonwire"
+	"encoding/json"
+	"github.com/stretchr/testify/mock"
+	"errors"
+)
+
+func TestNodeHelperFactory_create(t *testing.T) {
+	nhf := new(nodeHelperFactory)
+	nodeHelper := nhf.create(nil)
+	assert.NotNil(t, nodeHelper)
+}
+
+func TestNodeHelper_removeAllSessions_Positive_NothingToRemove(t *testing.T) {
+	cm := new(jsonwire.ClientMock)
+	nodeHelper := &nodeHelper{cm}
+	message := new(jsonwire.Sessions)
+	cm.On("Sessions").Return(message, nil)
+	_, err := nodeHelper.removeAllSessions()
+	assert.Nil(t, err)
+}
+
+func TestNodeHelper_removeAllSessions_Positive_SuccessRemove(t *testing.T) {
+	cm := new(jsonwire.ClientMock)
+	nodeHelper := &nodeHelper{cm}
+	sessions := new(jsonwire.Sessions)
+	sessions.Value = []struct {
+		ID           string          `json:"id"`
+		Capabilities json.RawMessage `json:"capabilities"`
+	}{
+		{ID: "lrololo", Capabilities: nil},
+	}
+	cm.On("Sessions").Return(sessions, nil)
+	message := new(jsonwire.Message)
+	cm.On("CloseSession", mock.AnythingOfType("string")).Return(message, nil)
+	_, err := nodeHelper.removeAllSessions()
+	assert.Nil(t, err)
+}
+
+func TestNodeHelper_removeAllSessions_Negative_Sessions_Error(t *testing.T) {
+	cm := new(jsonwire.ClientMock)
+	nodeHelper := &nodeHelper{cm}
+	cm.On("Sessions").Return(new(jsonwire.Sessions), errors.New("Err"))
+	_, err := nodeHelper.removeAllSessions()
+	assert.NotNil(t, err)
+}
+
+func TestNodeHelper_removeAllSessions_Negative_Sessions_MessageStatusNotOk(t *testing.T) {
+	cm := new(jsonwire.ClientMock)
+	nodeHelper := &nodeHelper{cm}
+	sessions := new(jsonwire.Sessions)
+	sessions.Status = 99999
+	cm.On("Sessions").Return(new(jsonwire.Sessions), errors.New("Err"))
+	_, err := nodeHelper.removeAllSessions()
+	assert.NotNil(t, err)
+}
+
+func TestNodeHelper_removeAllSessions_Negative_CloseSession_Error(t *testing.T) {
+	cm := new(jsonwire.ClientMock)
+	nodeHelper := &nodeHelper{cm}
+	sessions := new(jsonwire.Sessions)
+	sessions.Value = []struct {
+		ID           string          `json:"id"`
+		Capabilities json.RawMessage `json:"capabilities"`
+	}{
+		{ID: "lrololo", Capabilities: nil},
+	}
+	cm.On("Sessions").Return(sessions, nil)
+	message := new(jsonwire.Message)
+	cm.On("CloseSession", mock.AnythingOfType("string")).Return(message, errors.New("Err"))
+	_, err := nodeHelper.removeAllSessions()
+	assert.NotNil(t, err)
+}
+
+func TestNodeHelper_removeAllSessions_Negative_CloseSession_MessageStatusNotOk(t *testing.T) {
+	cm := new(jsonwire.ClientMock)
+	nodeHelper := &nodeHelper{cm}
+	sessions := new(jsonwire.Sessions)
+	sessions.Value = []struct {
+		ID           string          `json:"id"`
+		Capabilities json.RawMessage `json:"capabilities"`
+	}{
+		{ID: "lrololo", Capabilities: nil},
+	}
+	cm.On("Sessions").Return(sessions, nil)
+	message := new(jsonwire.Message)
+	message.Status = 999999
+	cm.On("CloseSession", mock.AnythingOfType("string")).Return(message, errors.New("Err"))
+	_, err := nodeHelper.removeAllSessions()
+	assert.NotNil(t, err)
+}
+


### PR DESCRIPTION
- fix
- tests

Суть проблемы: при вынесении логики резервирования нод в стратегии был забыт кусок кода, отвечающий за очистку персистентных нод от сессий.

В реквесте вынесен этот кусок и написаны тесты 