### PR TITLE
Fix python selenium capabilities comparator

### DIFF
--- a/pool/capabilities/comparator.go
+++ b/pool/capabilities/comparator.go
@@ -38,6 +38,9 @@ func (c *Comparator) Compare(desired Capabilities, available Capabilities) bool 
 		if !c.isRegistered(name) {
 			continue
 		}
+		if name == "platform" && currCap == "ANY" {
+			currCap = available[name]
+		}
 		if !reflect.DeepEqual(currCap, available[name]) {
 			return false
 		}


### PR DESCRIPTION
If capability not setted, than python selenium send default capability wich contain key `platform` with value `ANY`