### PR TITLE
 grid status method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,6 @@ Configurations are stored in json files. Example:
 | params.pod_creation_timeout | string as `12m`, `60s` | Max waiting time for creating a pod.  |
 | node_list.[].params.image   | string                 | Docker image with selenium.           |
 | node_list.[].params.port    | string                 | Port of selenium.                     |
+
+## API
+- `/grid/status` - a method returns a status of a grid

--- a/handlers/gridStatus.go
+++ b/handlers/gridStatus.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/qa-dev/jsonwire-grid/config"
+	"github.com/qa-dev/jsonwire-grid/pool"
+)
+
+// GridStatus - Returns a status.
+type GridStatus struct {
+	Pool   *pool.Pool
+	Config config.Config
+}
+
+type response struct {
+	NodeList []pool.Node   `json:"node_list"`
+	Config   config.Config `json:"config"`
+}
+
+func (h *GridStatus) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	nodeList, err := h.Pool.GetAll()
+	if err != nil {
+		http.Error(rw, fmt.Sprint("trying to get a node list from pool,", err), http.StatusInternalServerError)
+		return
+	}
+
+	resp := response{NodeList: nodeList, Config: h.Config}
+	respJSON, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(rw, fmt.Sprint("trying to encode a response,", err), http.StatusInternalServerError)
+		return
+	}
+
+	_, err = rw.Write(respJSON)
+	if err != nil {
+		log.Error("grid/status: write a response,", err)
+	}
+}

--- a/pool/node.go
+++ b/pool/node.go
@@ -22,14 +22,14 @@ type Node struct {
 	// The value may depend on the strategy:
 	// - for constant nodes ip: port
 	// - for temporary pod.name
-	Key             string
-	Type             NodeType
-	Address          string
-	Status           NodeStatus
-	SessionID        string
-	Updated          int64
-	Registered       int64
-	CapabilitiesList []capabilities.Capabilities
+	Key              string                      `json:"key"`
+	Type             NodeType                    `json:"type"`
+	Address          string                      `json:"address"`
+	Status           NodeStatus                  `json:"status"`
+	SessionID        string                      `json:"session_id"`
+	Updated          int64                       `json:"updated"`
+	Registered       int64                       `json:"registered"`
+	CapabilitiesList []capabilities.Capabilities `json:"capabilities_list"`
 }
 
 func (n *Node) String() string {


### PR DESCRIPTION
Fixes #36 

Hi, now I can't provide a web interface, but here is some API that can help you to get the information that you need.

That looks like this:
```
curl localhost:4444/grid/status -sS | jq "."
{
  "node_list": [
    {
      "key": "10.9.241.207:6666",
      "type": "persistent",
      "address": "10.9.241.207:6666",
      "status": "available",
      "session_id": "",
      "updated": 1572215422,
      "registered": 1572215422,
      "capabilities_list": [
        {
          "browserName": "firefox",
          "marionette": true,
          "maxInstances": 5,
          "platform": "MAC",
          "platformName": "MAC",
          "seleniumProtocol": "WebDriver",
          "server:CONFIG_UUID": "d4771bc0-6349-47be-8f10-f3198e5cd12f"
        },
        {
          "browserName": "chrome",
          "maxInstances": 5,
          "platform": "MAC",
          "platformName": "MAC",
          "seleniumProtocol": "WebDriver",
          "server:CONFIG_UUID": "25cb856d-913c-4f45-ae88-91a76d82e712"
        },
        {
          "browserName": "safari",
          "maxInstances": 1,
          "platform": "MAC",
          "platformName": "MAC",
          "seleniumProtocol": "WebDriver",
          "server:CONFIG_UUID": "5756e9c5-6b3a-4578-afa6-b029d00ad32e",
          "technologyPreview": false
        }
      ]
    }
  ],
  "config": {
    "logger": {
      "level": "debug"
    },
    "db": {
      "implementation": "local",
      "connection": ""
    },
    "grid": {
      "client_type": "selenium",
      "port": 4444,
      "strategy_list": [
        {
          "params": null,
          "type": "persistent",
          "limit": 0,
          "node_list": null
        }
      ],
      "busy_node_duration": "15m",
      "reserved_node_duration": "5m"
    }
  }
}
```
![work](https://user-images.githubusercontent.com/12721466/67643101-7cd54000-f924-11e9-8dff-68c8ce8cb528.jpg)
