### PR TITLE
Add API method '/grid/session/info'

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ Configurations are stored in json files. Example:
 
 ## API
 - `/grid/status` - a method returns a status of a grid
+- `/grid/session/info` - a returns a session info by session id. 
+ Еxample: `curl -X http://localhost:4444/grid/session/info?sessionid=9fc185d2-7a3d-4660-877f-cd4ca2a2f5c3`

--- a/handlers/sessionInfo.go
+++ b/handlers/sessionInfo.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/qa-dev/jsonwire-grid/pool"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+)
+
+// SessionInfo - Returns a session info (node address, status, etc)
+type SessionInfo struct {
+	Pool *pool.Pool
+}
+
+type sessionInfoResponse struct {
+	NodeAddress string          `json:"node_address"`
+	NodeType    pool.NodeType   `json:"node_type"`
+	Status      pool.NodeStatus `json:"node_status"`
+	SessionID   string          `json:"session_id"`
+	Updated     int64           `json:"updated"`
+	Registered  int64           `json:"registered"`
+}
+
+func (h *SessionInfo) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	sessionId := r.URL.Query().Get("sessionid")
+	if sessionId == "" {
+		http.Error(rw, fmt.Sprint("session id must be specified,"), http.StatusBadRequest)
+		return
+	}
+	node, err := h.Pool.GetNodeBySessionID(sessionId)
+	if err != nil {
+		http.Error(rw, fmt.Sprint("trying to get a session data,", err), http.StatusInternalServerError)
+		return
+	}
+
+	resp := sessionInfoResponse{
+		node.Address,
+		node.Type,
+		node.Status,
+		node.SessionID,
+		node.Updated,
+		node.Registered,
+	}
+	respJSON, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(rw, fmt.Sprint("trying to encode a response,", err), http.StatusInternalServerError)
+		return
+	}
+
+	_, err = rw.Write(respJSON)
+	if err != nil {
+		log.Error("session/info: write a response,", err)
+	}
+}

--- a/handlers/sessionInfo.go
+++ b/handlers/sessionInfo.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/qa-dev/jsonwire-grid/pool"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/qa-dev/jsonwire-grid/pool"
 )
 
 // SessionInfo - Returns a session info (node address, status, etc)

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func main() {
 	http.Handle("/session", middlewareWrap.Do(&handlers.CreateSession{Pool: poolInstance, ClientFactory: clientFactory}))        //wda
 	http.Handle("/grid/register", middlewareWrap.Do(&handlers.RegisterNode{Pool: poolInstance}))
 	http.Handle("/grid/status", middlewareWrap.Do(&handlers.GridStatus{Pool: poolInstance, Config: *cfg}))
+	http.Handle("/grid/session/info", middlewareWrap.Do(&handlers.SessionInfo{Pool: poolInstance}))
 	http.Handle("/grid/api/proxy", &handlers.APIProxy{Pool: poolInstance})
 	http.HandleFunc("/_info", heartbeat)
 	http.Handle("/", middlewareWrap.Do(&handlers.UseSession{Pool: poolInstance, Cache: cache}))


### PR DESCRIPTION
Add API method '/grid/session/info'. Returns session info( address, port, etc.) by session id